### PR TITLE
Add interactive phishing awareness training site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Just for Phishing - Cyber Safety Adventure</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="hero">
+      <img
+        class="hero__logo"
+        src="assets/JustforPhishingLogo.png"
+        alt="Just for Phishing logo"
+      />
+      <div class="hero__content">
+        <h1>Just for Phishing</h1>
+        <p>
+          Welcome to the cyber safety adventure! Work your way through short
+          mini-games to learn how phishers operate, practice safer habits, and
+          earn your Cyber Hygiene Certificate.
+        </p>
+        <button class="primary" id="startAdventure">Start the Adventure</button>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="level-card">
+        <div class="level-card__header">
+          <h2 id="levelTitle">Level 1: Spot the Phishy Email</h2>
+          <span class="badge" id="levelBadge">Beginner</span>
+        </div>
+        <p id="levelDescription">
+          Examine the message and choose the safest response.
+        </p>
+
+        <div class="scenario" id="scenario"></div>
+
+        <div class="choices" id="choices"></div>
+
+        <div class="feedback" id="feedback" role="alert" aria-live="polite"></div>
+
+        <div class="level-actions">
+          <button class="secondary" id="hintButton">Need a hint?</button>
+          <button class="primary" id="submitButton" disabled>Lock in answer</button>
+        </div>
+      </section>
+
+      <section class="progress">
+        <h3>Progress Tracker</h3>
+        <div class="progress__bar">
+          <div class="progress__bar-fill" id="progressFill"></div>
+        </div>
+        <ul class="progress__levels" id="progressLevels"></ul>
+        <div class="scoreboard">
+          <p><strong>Score:</strong> <span id="score">0</span> pts</p>
+          <p><strong>Streak:</strong> <span id="streak">0</span></p>
+        </div>
+      </section>
+
+      <section class="certificate" id="certificate" hidden>
+        <h2>Cyber Hygiene Certificate</h2>
+        <p>
+          Congratulations! You've cleared every level and proved your phishing
+          awareness skills. Fill out your name and generate a certificate to
+          share with your technology leader.
+        </p>
+        <label class="certificate__label" for="participantName"
+          >Your name</label
+        >
+        <input
+          class="certificate__input"
+          type="text"
+          id="participantName"
+          placeholder="Ada Lovelace"
+        />
+        <button class="primary" id="downloadCertificate">
+          Download certificate
+        </button>
+        <div class="certificate__preview" id="certificatePreview"></div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Built for education. Practice regularly, stay vigilant, and keep your
+        digital world safe.
+      </p>
+    </footer>
+
+    <template id="certificateTemplate">
+      <div class="certificate-sheet">
+        <h1>Cyber Hygiene Certificate</h1>
+        <p>This certifies that</p>
+        <h2 data-field="name">Ada Lovelace</h2>
+        <p>
+          has successfully completed the Just for Phishing training and
+          demonstrated strong cyber safety habits.
+        </p>
+        <div class="certificate-sheet__footer">
+          <span>Technology Readiness Team</span>
+          <span data-field="date"></span>
+        </div>
+      </div>
+    </template>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,453 @@
+const levels = [
+  {
+    id: 'level1',
+    title: 'Level 1: Spot the Phishy Email',
+    badge: 'Beginner',
+    description: 'Read the message carefully and decide the safest next step.',
+    scenario: `
+      <p><strong>Subject:</strong> Security Alert - Immediate Action Required</p>
+      <p><strong>From:</strong> TrustPay Support <code>account-security@support-paypai.com</code></p>
+      <p>
+        "We noticed suspicious activity on your account. Your access will be
+        suspended within <strong>12 minutes</strong> unless you verify your
+        identity."
+      </p>
+      <p><strong>Link preview:</strong> <code>http://trustpay-verify-info.com/login</code></p>
+    `,
+    options: [
+      {
+        id: 'a',
+        text: 'Click the link right away before the timer runs out.',
+        isCorrect: false,
+        feedback:
+          'Scammers often manufacture urgency so you act before thinking. Slow down and verify first.',
+      },
+      {
+        id: 'b',
+        text: 'Report the email as phishing, then navigate to TrustPay from a saved bookmark to double-check your account.',
+        isCorrect: true,
+        feedback:
+          'Perfect! Reporting and visiting the official site yourself keeps attackers out of your account.',
+      },
+      {
+        id: 'c',
+        text: 'Forward the email to coworkers to warn them of the attack.',
+        isCorrect: false,
+        feedback:
+          'Forwarding spreads the malicious link. Use your organization\'s reporting button instead.',
+      },
+    ],
+    hint: 'Look closely at the sender address and the countdown timer.',
+    points: 120,
+    explanation:
+      'Phishing emails impersonate brands and pressure you with fake deadlines. Always inspect addresses and visit the site through your own trusted bookmark.',
+  },
+  {
+    id: 'level2',
+    title: 'Level 2: Link Laboratory',
+    badge: 'Apprentice',
+    description: 'Hovering or tapping links tells you where you will really land.',
+    scenario: `
+      <p>
+        You receive a chat message: "Here is the secure payroll update portal"
+        with a shortened link <code>https://tinyurl.com/payroll2024</code>.
+      </p>
+      <button class="reveal-button" data-action="reveal-link">
+        Reveal destination URL
+      </button>
+      <span class="reveal-output" data-output></span>
+    `,
+    options: [
+      {
+        id: 'a',
+        text: 'Open the link in a private browser window. Private mode will block malware.',
+        isCorrect: false,
+        feedback:
+          'Private mode hides history but does not block malicious sites. You could still give up credentials.',
+      },
+      {
+        id: 'b',
+        text: 'Use a link expander or hover preview to confirm the destination before deciding.',
+        isCorrect: true,
+        feedback:
+          'Exactly. Expanding the URL shows the real destination so you can judge if it is trustworthy.',
+      },
+      {
+        id: 'c',
+        text: 'Ignore the message because all shortened links are scams.',
+        isCorrect: false,
+        feedback:
+          'Some legitimate services use short links. Instead of ignoring everything, verify where it leads.',
+      },
+    ],
+    hint: 'Tools like checkshorturl.com can show you the true destination of a short link.',
+    points: 140,
+    explanation:
+      'Before you click, preview the full URL. Check for misspellings, odd domains, or unexpected redirects.',
+  },
+  {
+    id: 'level3',
+    title: 'Level 3: Smishing Showdown',
+    badge: 'Defender',
+    description: 'Text messages can phish too. Recognize the traps.',
+    scenario: `
+      <p>
+        SMS from "Bank Notice": "Unusual withdrawal detected. Reply YES to
+        freeze account or call 1-800-555-0101 to speak with security now."
+      </p>
+      <ul class="timeline">
+        <li>Unsolicited alert, high-pressure instructions</li>
+        <li>Phone number not listed on your debit card or the bank website</li>
+        <li>Requests sensitive action through a text reply</li>
+      </ul>
+    `,
+    options: [
+      {
+        id: 'a',
+        text: 'Call the number in the text immediately to keep your money safe.',
+        isCorrect: false,
+        feedback:
+          'Attackers set up fake call centers. Use the phone number printed on your bank card instead.',
+      },
+      {
+        id: 'b',
+        text: 'Reply YES so the scammer knows you are alert and leaves you alone.',
+        isCorrect: false,
+        feedback:
+          'Replying confirms your phone number is active and can trigger more scams.',
+      },
+      {
+        id: 'c',
+        text: 'Do not reply. Contact the bank through the number saved in your contacts to confirm.',
+        isCorrect: true,
+        feedback:
+          'Nice! Verifying with an official channel keeps control in your hands.',
+      },
+    ],
+    hint: 'Legitimate banks rarely demand instant replies via text. Contact them through a trusted number.',
+    points: 160,
+    explanation:
+      'Smishing relies on urgency. Disconnect from the message and re-establish contact on your own terms.',
+  },
+  {
+    id: 'level4',
+    title: 'Level 4: Inbox Boss Battle',
+    badge: 'Phish Fighter',
+    description: 'Apply everything you learned to a layered phishing attempt.',
+    scenario: `
+      <p>
+        You are asked to approve an invoice for a vendor. The sender is your
+        "CEO" with an email of <code>ceo-office@company-leadership.net</code>.
+        There is an attached PDF labeled <strong>Invoice_Q3.zip</strong>.
+      </p>
+      <p>
+        The message says the CEO needs this paid in the next 10 minutes while
+        they are boarding a flight and cannot talk.
+      </p>
+    `,
+    options: [
+      {
+        id: 'a',
+        text: 'Open the attachment and skim it. It is faster than bothering anyone else.',
+        isCorrect: false,
+        feedback:
+          'Zip attachments can hide malware. Opening without verifying could compromise your device.',
+      },
+      {
+        id: 'b',
+        text: 'Call the CEO using the number you already have to verify the request before acting.',
+        isCorrect: true,
+        feedback:
+          'Well played! Verification through a separate, trusted channel defeats most business email compromise scams.',
+      },
+      {
+        id: 'c',
+        text: 'Send the payment. Executives expect fast action and you can review later.',
+        isCorrect: false,
+        feedback:
+          'Rushing payments without validation is exactly what attackers want.',
+      },
+    ],
+    hint: 'Spoofed executive requests are common. Slow down and confirm out-of-band.',
+    points: 200,
+    explanation:
+      'Business email compromise attacks rely on trust and urgency. Always verify payment requests with a quick call or message through a known channel.',
+  },
+];
+
+const levelTitle = document.getElementById('levelTitle');
+const levelBadge = document.getElementById('levelBadge');
+const levelDescription = document.getElementById('levelDescription');
+const scenarioEl = document.getElementById('scenario');
+const choicesEl = document.getElementById('choices');
+const feedbackEl = document.getElementById('feedback');
+const hintButton = document.getElementById('hintButton');
+const submitButton = document.getElementById('submitButton');
+const progressFill = document.getElementById('progressFill');
+const progressLevels = document.getElementById('progressLevels');
+const scoreEl = document.getElementById('score');
+const streakEl = document.getElementById('streak');
+const startButton = document.getElementById('startAdventure');
+const certificateSection = document.getElementById('certificate');
+const participantName = document.getElementById('participantName');
+const downloadCertificateButton = document.getElementById('downloadCertificate');
+const certificatePreview = document.getElementById('certificatePreview');
+
+let currentLevelIndex = 0;
+let selectedOptionId = null;
+let score = 0;
+let streak = 0;
+
+const STARTING_SCORE = 0;
+const INCORRECT_PENALTY = 20;
+
+function initializeProgress() {
+  levels.forEach((level, index) => {
+    const li = document.createElement('li');
+    li.textContent = `${index + 1}. ${level.badge}`;
+    li.id = `progress-${level.id}`;
+    progressLevels.appendChild(li);
+  });
+}
+
+function renderLevel(index) {
+  const level = levels[index];
+  levelTitle.textContent = level.title;
+  levelBadge.textContent = level.badge;
+  levelDescription.textContent = level.description;
+  scenarioEl.innerHTML = level.scenario;
+  feedbackEl.textContent = '';
+  feedbackEl.className = 'feedback';
+  selectedOptionId = null;
+  submitButton.disabled = true;
+  submitButton.textContent = index === levels.length - 1 ? 'Lock in answer' : 'Lock in answer';
+  submitButton.dataset.state = 'answer';
+
+  choicesEl.innerHTML = '';
+  level.options.forEach((option, optionIndex) => {
+    const label = document.createElement('label');
+    label.className = 'choice';
+    label.innerHTML = `
+      <input type="radio" name="choice" value="${option.id}" />
+      <div>
+        <strong>Option ${String.fromCharCode(65 + optionIndex)}</strong>
+        <p>${option.text}</p>
+      </div>
+    `;
+
+    const input = label.querySelector('input');
+    input.addEventListener('change', () => {
+      selectedOptionId = option.id;
+      submitButton.disabled = false;
+      choicesEl
+        .querySelectorAll('.choice')
+        .forEach((choice) => choice.classList.remove('choice--selected'));
+      label.classList.add('choice--selected');
+    });
+
+    choicesEl.appendChild(label);
+  });
+
+  attachScenarioInteractions(level);
+}
+
+function attachScenarioInteractions(level) {
+  const revealButton = scenarioEl.querySelector('[data-action="reveal-link"]');
+  if (revealButton) {
+    const output = scenarioEl.querySelector('[data-output]');
+    revealButton.addEventListener('click', () => {
+      output.textContent = 'Revealed URL: https://malicious-payroll-login.netlify.app';
+      output.style.color = '#f97316';
+      revealButton.disabled = true;
+      revealButton.textContent = 'Link revealed';
+    });
+  }
+}
+
+function updateProgress() {
+  const completed = progressLevels.querySelectorAll('.completed').length;
+  const total = levels.length;
+  const percent = Math.round((completed / total) * 100);
+  progressFill.style.width = `${percent}%`;
+}
+
+function handleAnswer() {
+  if (!selectedOptionId) return;
+
+  const level = levels[currentLevelIndex];
+  const choice = level.options.find((option) => option.id === selectedOptionId);
+  if (!choice) return;
+
+  if (choice.isCorrect) {
+    streak += 1;
+    score += level.points + streak * 10;
+    feedbackEl.textContent = `✅ ${choice.feedback} ${level.explanation}`;
+    feedbackEl.className = 'feedback feedback--correct';
+    markLevelComplete(level.id);
+    submitButton.textContent =
+      currentLevelIndex === levels.length - 1 ? 'Claim certificate' : 'Continue to next level';
+    submitButton.dataset.state = 'next';
+    hintButton.disabled = true;
+  } else {
+    streak = 0;
+    score = Math.max(STARTING_SCORE, score - INCORRECT_PENALTY);
+    feedbackEl.textContent = `⚠️ ${choice.feedback}`;
+    feedbackEl.className = 'feedback feedback--incorrect';
+  }
+
+  updateScoreboard();
+}
+
+function markLevelComplete(levelId) {
+  const li = document.getElementById(`progress-${levelId}`);
+  li?.classList.add('completed');
+  updateProgress();
+}
+
+function goToNextLevel() {
+  if (currentLevelIndex < levels.length - 1) {
+    currentLevelIndex += 1;
+    hintButton.disabled = false;
+    renderLevel(currentLevelIndex);
+    window.scrollTo({ top: document.querySelector('.container').offsetTop - 40, behavior: 'smooth' });
+  } else {
+    showCertificate();
+  }
+}
+
+function updateScoreboard() {
+  scoreEl.textContent = score;
+  streakEl.textContent = streak;
+}
+
+function showHint() {
+  const level = levels[currentLevelIndex];
+  feedbackEl.textContent = `💡 Hint: ${level.hint}`;
+  feedbackEl.className = 'feedback feedback--hint';
+}
+
+function showCertificate() {
+  certificateSection.hidden = false;
+  document.getElementById(`progress-${levels[currentLevelIndex].id}`)?.classList.add('completed');
+  updateProgress();
+  updateCertificatePreview(getCertificateName());
+  certificateSection.scrollIntoView({ behavior: 'smooth' });
+}
+
+function getCertificateName() {
+  return participantName.value.trim() || 'Cyber Defender';
+}
+
+function updateCertificatePreview(name) {
+  certificatePreview.innerHTML = '';
+  const template = document.getElementById('certificateTemplate');
+  const clone = template.content.cloneNode(true);
+  clone.querySelector('[data-field="name"]').textContent = name;
+  clone.querySelector('[data-field="date"]').textContent = new Date().toLocaleDateString();
+  certificatePreview.appendChild(clone);
+}
+
+function openCertificateWindow(name) {
+  const date = new Date().toLocaleDateString();
+  const certificateWindow = window.open('', '_blank', 'width=900,height=700');
+  if (!certificateWindow) {
+    alert('Please allow pop-ups to download your certificate.');
+    return;
+  }
+
+  certificateWindow.document.write(`
+    <html>
+      <head>
+        <title>Cyber Hygiene Certificate</title>
+        <style>
+          body {
+            font-family: 'Montserrat', 'Segoe UI', sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #e0f2fe;
+            margin: 0;
+            height: 100vh;
+          }
+          .sheet {
+            width: 760px;
+            border: 12px solid #38bdf8;
+            padding: 3rem 2.5rem;
+            text-align: center;
+            background: #f8fafc;
+            color: #0f172a;
+            border-radius: 1rem;
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.25);
+          }
+          h1 {
+            margin: 0 0 1rem;
+            font-size: 2.6rem;
+            letter-spacing: 0.05em;
+          }
+          h2 {
+            margin: 1.5rem 0 0.5rem;
+            font-size: 2rem;
+            color: #0284c7;
+          }
+          p {
+            font-size: 1.1rem;
+            line-height: 1.6;
+          }
+          .footer {
+            margin-top: 2.5rem;
+            display: flex;
+            justify-content: space-between;
+            font-weight: 600;
+            color: #475569;
+          }
+        </style>
+      </head>
+      <body>
+        <div class="sheet">
+          <h1>Cyber Hygiene Certificate</h1>
+          <p>This certifies that</p>
+          <h2>${name}</h2>
+          <p>
+            has successfully completed the Just for Phishing training journey
+            and demonstrated a commitment to safe cyber practices.
+          </p>
+          <div class="footer">
+            <span>Technology Readiness Team</span>
+            <span>${date}</span>
+          </div>
+        </div>
+      </body>
+    </html>
+  `);
+  certificateWindow.document.close();
+  certificateWindow.focus();
+  certificateWindow.print();
+}
+
+submitButton.addEventListener('click', () => {
+  if (submitButton.dataset.state === 'next') {
+    goToNextLevel();
+    return;
+  }
+  handleAnswer();
+});
+
+hintButton.addEventListener('click', showHint);
+
+startButton.addEventListener('click', () => {
+  document.querySelector('.container').scrollIntoView({ behavior: 'smooth' });
+});
+
+participantName.addEventListener('input', () => {
+  updateCertificatePreview(getCertificateName());
+});
+
+downloadCertificateButton.addEventListener('click', () => {
+  const name = getCertificateName();
+  openCertificateWindow(name);
+});
+
+initializeProgress();
+renderLevel(currentLevelIndex);
+updateScoreboard();
+updateCertificatePreview(getCertificateName());

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,383 @@
+:root {
+  --background: #0f172a;
+  --surface: #111827;
+  --surface-light: #1f2937;
+  --primary: #38bdf8;
+  --primary-dark: #0284c7;
+  --accent: #a855f7;
+  --success: #22c55e;
+  --danger: #ef4444;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --font: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  background: radial-gradient(circle at top left, #1e293b, var(--background));
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1.5rem;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: var(--text);
+  box-shadow: 0 10px 25px rgba(56, 189, 248, 0.3);
+}
+
+.primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(168, 85, 247, 0.35);
+}
+
+.secondary {
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+}
+
+.secondary:hover:not(:disabled) {
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.hero {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(2rem, 4vw, 4rem);
+  align-items: center;
+  justify-items: center;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.25), transparent),
+    radial-gradient(circle at 80% 10%, rgba(168, 85, 247, 0.2), transparent);
+}
+
+.hero__logo {
+  width: min(280px, 60vw);
+  filter: drop-shadow(0 20px 35px rgba(56, 189, 248, 0.35));
+}
+
+.hero__content {
+  text-align: center;
+  max-width: 600px;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  margin-bottom: 0.5rem;
+}
+
+.hero p {
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.container {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  flex: 1;
+}
+
+.level-card {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  backdrop-filter: blur(10px);
+}
+
+.level-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.2);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.scenario {
+  background: var(--surface-light);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  line-height: 1.5;
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.08);
+}
+
+.scenario code {
+  display: inline-block;
+  background: rgba(15, 23, 42, 0.7);
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.35rem;
+  color: var(--primary);
+}
+
+.choices {
+  display: grid;
+  gap: 1rem;
+}
+
+.choice {
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: 1rem 1.25rem;
+  text-align: left;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.choice:hover {
+  border-color: rgba(56, 189, 248, 0.4);
+  transform: translateY(-1px);
+}
+
+.choice input {
+  accent-color: var(--primary);
+  margin-right: 0.75rem;
+}
+
+.feedback {
+  min-height: 2.5rem;
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid transparent;
+  display: none;
+  line-height: 1.4;
+}
+
+.feedback--correct {
+  display: block;
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #bbf7d0;
+}
+
+.feedback--incorrect {
+  display: block;
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+}
+
+.progress {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 1.5rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  display: grid;
+  gap: 1.25rem;
+  height: max-content;
+}
+
+.progress__bar {
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  overflow: hidden;
+}
+
+.progress__bar-fill {
+  height: 100%;
+  width: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  transition: width 0.3s ease;
+}
+
+.progress__levels {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.progress__levels li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--muted);
+}
+
+.progress__levels li.completed {
+  color: var(--success);
+}
+
+.progress__levels li::before {
+  content: '◎';
+  color: rgba(148, 163, 184, 0.4);
+}
+
+.progress__levels li.completed::before {
+  content: '★';
+  color: var(--accent);
+}
+
+.scoreboard {
+  display: grid;
+  gap: 0.5rem;
+  color: var(--muted);
+}
+
+.certificate {
+  grid-column: 1 / -1;
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  display: grid;
+  gap: 1rem;
+}
+
+.certificate__label {
+  font-weight: 600;
+}
+
+.certificate__input {
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.7);
+  color: var(--text);
+}
+
+.certificate__input:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.5);
+  outline-offset: 2px;
+}
+
+.certificate__preview {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+.certificate-sheet {
+  width: min(600px, 100%);
+  border: 10px solid rgba(56, 189, 248, 0.3);
+  padding: 3rem 2.5rem;
+  text-align: center;
+  background: #f8fafc;
+  color: #0f172a;
+  font-family: 'Montserrat', 'Segoe UI', sans-serif;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+  border-radius: 1rem;
+}
+
+.certificate-sheet h1 {
+  margin: 0 0 1rem;
+  font-size: 2.2rem;
+}
+
+.certificate-sheet h2 {
+  margin: 0.5rem 0 1.5rem;
+  font-size: 1.8rem;
+  color: #0284c7;
+}
+
+.certificate-sheet__footer {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+  color: #475569;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 780px) {
+  .hero {
+    padding-bottom: 2rem;
+  }
+
+  .level-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .badge {
+    align-self: flex-start;
+  }
+}
+.choice--selected {
+  border-color: rgba(56, 189, 248, 0.5);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.15);
+}
+
+.feedback--hint {
+  display: block;
+  border-color: rgba(56, 189, 248, 0.4);
+  color: #bae6fd;
+}
+
+.reveal-button {
+  margin-top: 0.75rem;
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--primary);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.reveal-output {
+  display: inline-block;
+  margin-left: 0.5rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.timeline {
+  margin-top: 1rem;
+  padding-left: 1.25rem;
+  border-left: 2px dashed rgba(148, 163, 184, 0.3);
+}
+
+.timeline li {
+  margin-bottom: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- create a hero landing page and level card layout for the Just for Phishing training experience
- implement four gamified phishing-awareness levels with scoring, hints, and progress tracking
- add certificate preview and printable download for successful participants

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd2298790c8333bfbfd0bd34cccc18