### PR TITLE
Add Phish or Treat Halloween challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         <p>Phishing training journey and demo.</p>
         <div class="hero__actions">
           <button id="start-level-1" class="btn">Start Level 1</button>
+          <a class="btn btn--pumpkin" href="phish-or-treat.html">Phish or Treat Challenge</a>
           <a class="btn btn--secondary" href="mfa-fatigue.html">MFA-Fatigue Drill</a>
         </div>
       </div>

--- a/phish-or-treat.html
+++ b/phish-or-treat.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Phish or Treat — 3 Minute Halloween Challenge</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/JustForPhishingLogo.png" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="halloween-body">
+  <div class="page phish-treat-page">
+    <header class="spooky-hero">
+      <div class="spooky-hero__glow"></div>
+      <div class="spooky-hero__inner container">
+        <a class="back-link" href="index.html">&#8592; Back to Cyber Hygiene Quest</a>
+        <div class="spooky-badge">Phish or Treat</div>
+        <h1>Race the clock in this Halloween phishing hunt</h1>
+        <p>In exactly three minutes, investigate each eerie message and decide if it&rsquo;s a malicious phish or a legit treat. Trust the clues, move quickly, and don&rsquo;t let the monsters snatch your data!</p>
+        <div class="challenge-controls">
+          <div id="challenge-countdown" class="countdown countdown--pumpkin">03:00</div>
+          <button id="start-challenge" class="btn btn--pumpkin" type="button">Start 3 Minute Challenge</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="container challenge-main">
+      <section class="card card--moonlight">
+        <h2>How the 180-second sprint works</h2>
+        <ul class="spooky-list">
+          <li><strong>Investigate quickly:</strong> Flip through each message card and mark it as a phish or treat.</li>
+          <li><strong>Spot the clues:</strong> Hover over links, domains, attachments, and tone changes for telltale red flags.</li>
+          <li><strong>Beat the buzzer:</strong> Submit before the three-minute timer hits zero or the game will lock in your answers.</li>
+        </ul>
+        <p class="helper-text">Need a hint? Safe messages include verifiable senders and no sudden requests for credentials. When in doubt, report the phish!</p>
+      </section>
+
+      <section class="card challenge-panel">
+        <form id="challenge-form" novalidate>
+          <div id="scenario-list" class="scenario-grid">
+            <div class="scenario-placeholder">
+              <p>Press <strong>Start 3 Minute Challenge</strong> to reveal six suspicious (and not-so-suspicious) Halloween messages.</p>
+            </div>
+          </div>
+          <div class="challenge-actions">
+            <div id="progress-pill" class="progress-pill">0/6 marked</div>
+            <button id="submit-challenge" class="btn btn--secondary" type="submit" disabled>Submit responses</button>
+          </div>
+        </form>
+        <div id="challenge-feedback" class="feedback" aria-live="polite">Your mission awaits...</div>
+        <div id="challenge-summary" class="summary-banner hidden" aria-live="polite"></div>
+      </section>
+    </main>
+  </div>
+
+  <script src="phish-or-treat.js"></script>
+</body>
+</html>

--- a/phish-or-treat.js
+++ b/phish-or-treat.js
@@ -1,0 +1,298 @@
+const START_TIME_SECONDS = 180;
+const countdownEl = document.getElementById('challenge-countdown');
+const startBtn = document.getElementById('start-challenge');
+const form = document.getElementById('challenge-form');
+const scenarioList = document.getElementById('scenario-list');
+const submitBtn = document.getElementById('submit-challenge');
+const progressPill = document.getElementById('progress-pill');
+const feedbackEl = document.getElementById('challenge-feedback');
+const summaryEl = document.getElementById('challenge-summary');
+
+const SCENARIOS = [
+  {
+    id: 'bonus',
+    label: 'Pumpkin Bonus Portal',
+    sender: '"PumpkinFest HR" <hr@pumpkinpatchpay.com>',
+    subject: 'Last call: confirm your Halloween bonus',
+    preview:
+      'We conjured a surprise PumpkinFest bonus just for you. Log into the payroll portal within 30 minutes or the treat evaporates! Link: http://bonus-patchpay.com/login',
+    detail: 'Attachment: BonusForm.html',
+    isPhish: true,
+    action: 'Report the email to security and confirm with HR via the intranet instead of following the link.',
+    insights: [
+      'The sending domain pumpkinpatchpay.com does not match the company payroll provider.',
+      'Time pressure combined with an HTTP link is a classic credential harvest tactic.',
+      'HTML attachments are often used to mimic login portals and steal passwords.'
+    ]
+  },
+  {
+    id: 'contest',
+    label: 'Costume Contest Briefing',
+    sender: 'Facilities Team <facilities@candorcorp.com>',
+    subject: 'Friday: Costume parade routes & badge reminder',
+    preview:
+      'Parade steps off at 3 PM. Bring your badge for after-hours access and check the official map on the intranet. Reply with your team name for the bracket.',
+    detail: 'Link: https://intranet.candorcorp.com/events/costumes',
+    isPhish: false,
+    action: 'RSVP through the intranet site and remind teammates to wear badges after hours.',
+    insights: [
+      'Comes from the verified facilities@candorcorp.com domain you recognize.',
+      'Links point to the authenticated intranet over HTTPS, not a look-alike site.',
+      'No unexpected attachment or request for sensitive data accompanies the reminder.'
+    ]
+  },
+  {
+    id: 'update',
+    label: 'Shadowy Patch Alert',
+    sender: 'IT Support <alerts@0ffice365-security.com>',
+    subject: 'Immediate install required: Outlook Dark Mode Patch',
+    preview:
+      "A vulnerability in Outlook's Dark Mode was found. Download the patch from the mirror mirror://nightfix.exe and run it before midnight to avoid lockout.",
+    detail: 'Mirror link: http://nightfix.exe',
+    isPhish: true,
+    action: 'Ignore the download, report the message, and install patches only through managed software center.',
+    insights: [
+      'Sender uses 0ffice365 with a zero instead of the legitimate Microsoft domain.',
+      'Executable download links over HTTP are unsafe and bypass corporate deployment.',
+      'IT would never threaten lockout for skipping an unofficial patch.'
+    ]
+  },
+  {
+    id: 'giftcards',
+    label: 'Last-Minute Treats',
+    sender: 'CEO <d.moonlight@candorcorp-leadership.com>',
+    subject: 'Need 15 e-gift cards before the board call',
+    preview:
+      "I'm heading into a board meeting and forgot the pumpkin gift cards. Buy 15 cards and send the codes back quietly. I will reimburse you later tonight.",
+    detail: 'Marked as High Importance',
+    isPhish: true,
+    action: 'Call the executive assistant on a trusted number and report the suspicious request immediately.',
+    insights: [
+      'Spoofed domain candorcorp-leadership.com is not the real corporate domain.',
+      'Urgent financial purchase requests are a hallmark of CEO fraud schemes.',
+      'Payment instructions request secrecy and reimbursement later, another red flag.'
+    ]
+  },
+  {
+    id: 'training',
+    label: 'Security Awareness Treat',
+    sender: 'Security Awareness <training@candorcorp.com>',
+    subject: 'Pumpkin spice phishing lab — October 31 session',
+    preview:
+      'Reserve your seat for a 20 minute phishing lab. Session will be hosted in the auditorium. Register through LMS and bring a laptop for hands-on practice.',
+    detail: 'Link: https://lms.candorcorp.com/course/hauntingsafely',
+    isPhish: false,
+    action: 'Enroll through the LMS portal and encourage your team to attend the refresher.',
+    insights: [
+      'Sender and links match the normal corporate training system you already trust.',
+      'Encourages sign-up through existing LMS rather than emailing personal data.',
+      'Details align with other internal announcements and no scare tactics are used.'
+    ]
+  },
+  {
+    id: 'delivery',
+    label: 'Night Courier Notice',
+    sender: 'Shipping Notice <alerts@jackolantern-logistics.com>',
+    subject: 'Package stalled: confirm address for haunted delivery',
+    preview:
+      'Your costume props are delayed. Open the attached invoice to release the shipment tonight or the props go back to sender.',
+    detail: 'Attachment: invoice.zip.js',
+    isPhish: true,
+    action: 'Do not open the attachment. Report and delete the message, then check your real order history.',
+    insights: [
+      'Attachment ends in .zip.js indicating a disguised script that could run malware.',
+      "Logistics domain is unrelated to the store you ordered from and wasn't expected.",
+      'Uses fear of delay to drive an unsafe attachment download.'
+    ]
+  }
+];
+
+let timeRemaining = START_TIME_SECONDS;
+let timerId = null;
+let challengeActive = false;
+let hasSubmitted = false;
+
+function formatTime(totalSeconds) {
+  const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, '0');
+  const seconds = Math.floor(totalSeconds % 60).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+function renderScenarios() {
+  const cards = SCENARIOS.map((scenario, index) => {
+    const radios = `
+      <div class="scenario-choice-row">
+        <label class="choice-chip">
+          <input type="radio" name="scenario-${index}" value="treat" data-index="${index}">
+          <span>🍬 Treat</span>
+        </label>
+        <label class="choice-chip choice-chip--danger">
+          <input type="radio" name="scenario-${index}" value="phish" data-index="${index}">
+          <span>🎃 Phish</span>
+        </label>
+      </div>
+    `;
+
+    return `
+      <article class="scenario-card" data-index="${index}">
+        <header class="scenario-header">
+          <div class="scenario-label">Case ${index + 1}</div>
+          <div class="scenario-tag">${scenario.label}</div>
+        </header>
+        <div class="scenario-meta">
+          <div><strong>From:</strong> ${scenario.sender}</div>
+          <div><strong>Subject:</strong> ${scenario.subject}</div>
+        </div>
+        <p class="scenario-preview">${scenario.preview}</p>
+        <p class="scenario-detail">${scenario.detail}</p>
+        ${radios}
+        <div class="scenario-reveal hidden">
+          <p class="reveal-result"></p>
+          <ul class="reveal-insights"></ul>
+          <p class="reveal-action"></p>
+        </div>
+      </article>
+    `;
+  }).join('');
+
+  scenarioList.innerHTML = cards;
+}
+
+function resetChallenge() {
+  form.reset();
+  renderScenarios();
+  updateProgress();
+  feedbackEl.textContent = 'Identify each message as a phish or treat before time runs out!';
+  summaryEl.classList.add('hidden');
+  summaryEl.textContent = '';
+  submitBtn.disabled = false;
+  submitBtn.textContent = 'Submit responses';
+}
+
+function startChallenge() {
+  if (challengeActive) return;
+  challengeActive = true;
+  hasSubmitted = false;
+  timeRemaining = START_TIME_SECONDS;
+  countdownEl.textContent = formatTime(timeRemaining);
+  countdownEl.classList.remove('countdown--warning', 'countdown--danger');
+  startBtn.disabled = true;
+  startBtn.textContent = 'Challenge running...';
+  resetChallenge();
+  tickCountdown();
+  timerId = setInterval(tickCountdown, 1000);
+}
+
+function tickCountdown() {
+  if (!challengeActive) return;
+  countdownEl.textContent = formatTime(timeRemaining);
+
+  if (timeRemaining <= 60) {
+    countdownEl.classList.add('countdown--warning');
+  }
+  if (timeRemaining <= 20) {
+    countdownEl.classList.add('countdown--danger');
+  }
+
+  if (timeRemaining <= 0) {
+    finishChallenge(true);
+    return;
+  }
+
+  timeRemaining -= 1;
+}
+
+function updateProgress() {
+  if (!progressPill) return;
+  const answered = SCENARIOS.reduce((count, _, index) => {
+    return count + (form.querySelector(`input[name="scenario-${index}"]:checked`) ? 1 : 0);
+  }, 0);
+  progressPill.textContent = `${answered}/${SCENARIOS.length} marked`;
+
+  if (challengeActive && !hasSubmitted) {
+    if (answered === SCENARIOS.length) {
+      feedbackEl.textContent = 'All set! Submit when you are confident in your calls.';
+    } else {
+      const remaining = SCENARIOS.length - answered;
+      feedbackEl.innerHTML = `Keep going — ${remaining} more ${remaining === 1 ? 'message' : 'messages'} to classify.`;
+    }
+  }
+}
+
+function finishChallenge(autoSubmitted = false) {
+  if (hasSubmitted) return;
+  hasSubmitted = true;
+  challengeActive = false;
+  clearInterval(timerId);
+  timerId = null;
+
+  startBtn.disabled = false;
+  startBtn.textContent = 'Restart the challenge';
+  submitBtn.disabled = true;
+  submitBtn.textContent = autoSubmitted ? 'Time expired' : 'Submitted';
+
+  let score = 0;
+
+  SCENARIOS.forEach((scenario, index) => {
+    const choice = form.querySelector(`input[name="scenario-${index}"]:checked`);
+    const userAnswer = choice ? choice.value : null;
+    const isCorrect = userAnswer === (scenario.isPhish ? 'phish' : 'treat');
+
+    if (isCorrect) score += 1;
+
+    const card = scenarioList.querySelector(`.scenario-card[data-index="${index}"]`);
+    if (!card) return;
+
+    card.classList.toggle('scenario-card--correct', isCorrect);
+    card.classList.toggle('scenario-card--incorrect', !isCorrect);
+
+    const reveal = card.querySelector('.scenario-reveal');
+    if (!reveal) return;
+
+    const resultEl = reveal.querySelector('.reveal-result');
+    const insightsList = reveal.querySelector('.reveal-insights');
+    const actionEl = reveal.querySelector('.reveal-action');
+
+    if (resultEl) {
+      resultEl.textContent = scenario.isPhish
+        ? 'It was a phish. Trust your instincts and report!'
+        : 'A genuine treat! Still stay vigilant with every click.';
+      resultEl.classList.toggle('reveal-result--correct', isCorrect);
+      resultEl.classList.toggle('reveal-result--incorrect', !isCorrect);
+    }
+
+    if (insightsList) {
+      insightsList.innerHTML = scenario.insights.map((item) => `<li>${item}</li>`).join('');
+    }
+
+    if (actionEl) {
+      actionEl.textContent = scenario.action;
+    }
+
+    reveal.classList.remove('hidden');
+  });
+
+  const total = SCENARIOS.length;
+  const accuracy = Math.round((score / total) * 100);
+  const summaryPrefix = autoSubmitted ? "Time's up!" : score === total ? 'Flawless victory!' : 'Challenge complete!';
+  summaryEl.textContent = `${summaryPrefix} You spotted ${score} of ${total} correctly (${accuracy}% accuracy).`;
+  summaryEl.classList.remove('hidden');
+  feedbackEl.textContent = autoSubmitted
+    ? 'The moon struck midnight before you finished. Review the reveals to study each clue.'
+    : 'Review the reveals to reinforce each clue before trying again.';
+}
+
+startBtn?.addEventListener('click', startChallenge);
+
+form?.addEventListener('change', (event) => {
+  if (!(event.target instanceof HTMLInputElement)) return;
+  if (event.target.type === 'radio') {
+    updateProgress();
+  }
+});
+
+form?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  if (!challengeActive) return;
+  finishChallenge(false);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,6 @@
 :root{
   --ink:#0d1220; --bg:#0a0f1f; --card:#10172a; --accent:#2dd4bf; --accent-2:#22d3ee; --muted:#9aa4b2; --border:#1f2a44;
+  --pumpkin:#f97316; --pumpkin-ember:#fb923c; --candy:#fcd34d; --midnight:#120a26; --midnight-2:#1c123a; --violet:#7c3aed;
 }
 *{box-sizing:border-box} html,body{margin:0;padding:0}
 body{font-family:"Montserrat",system-ui,Segoe UI,Arial,sans-serif;color:#e6eefb;background:linear-gradient(180deg,var(--bg),#0b1329 35%,#0a0f1f)}
@@ -15,9 +16,13 @@ p{color:var(--muted);margin:0 0 18px}
 .btn:disabled{opacity:.45;cursor:not-allowed;box-shadow:none;transform:none}
 .btn--secondary{background:transparent;color:var(--accent-2);border:1px solid rgba(34,211,238,.4);box-shadow:inset 0 0 0 1px rgba(34,211,238,.2)}
 .btn--secondary:hover{background:rgba(34,211,238,.12);box-shadow:0 8px 20px rgba(34,211,238,.15)}
+.btn--pumpkin{background:linear-gradient(90deg,var(--pumpkin),var(--pumpkin-ember));color:#220f03}
+.btn--pumpkin:hover{transform:translateY(-1px);box-shadow:0 8px 24px rgba(249,115,22,.4)}
 .card{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:18px;margin:24px 0}
 .hidden{display:none}
 .helper-text{color:var(--muted);font-size:.92rem;line-height:1.5;margin:12px 0 0}
+.back-link{display:inline-flex;align-items:center;gap:8px;color:var(--muted);font-weight:600;text-decoration:none;margin-bottom:18px}
+.back-link:hover{color:var(--accent-2)}
 
 .drill-header{padding:40px 0;text-align:center}
 .drill-header .back-link{display:inline-flex;align-items:center;gap:8px;color:var(--muted);font-weight:600;text-decoration:none;margin-bottom:18px}
@@ -64,3 +69,53 @@ p{color:var(--muted);margin:0 0 18px}
 .event-log{margin-top:18px;border-top:1px solid var(--border);padding-top:16px;font-size:.85rem;color:var(--muted);display:grid;gap:12px;max-height:220px;overflow-y:auto}
 .event-log-entry strong{color:#f8fbff}
 .summary-banner{margin-top:20px;padding:16px;border-radius:12px;border:1px solid rgba(45,212,191,.28);background:rgba(13,32,45,.85);color:#d6faff;font-weight:600;text-align:center}
+
+.halloween-body{background:radial-gradient(circle at top,#1f0b2e,#0b0a18 58%,#04030a);color:#f4efff;min-height:100vh}
+.phish-treat-page .card{background:rgba(18,16,42,.92);border-color:rgba(96,68,180,.45)}
+.spooky-hero{position:relative;padding:72px 0 64px;overflow:hidden;background:linear-gradient(160deg,rgba(15,9,32,.95),rgba(34,16,52,.8))}
+.spooky-hero__glow{position:absolute;inset:-30% -20% auto -20%;height:120%;background:radial-gradient(circle at 50% 35%,rgba(249,115,22,.45),rgba(124,58,237,.12) 48%,rgba(10,8,26,0) 68%);filter:blur(4px);opacity:.9}
+.spooky-hero__inner{position:relative;text-align:center;z-index:1;display:flex;flex-direction:column;align-items:center;gap:18px}
+.spooky-hero h1{font-size:2.6rem;max-width:780px;margin:0}
+.spooky-hero p{max-width:760px;margin:0;color:#f7e9ff;font-size:1.04rem}
+.spooky-badge{display:inline-flex;align-items:center;gap:8px;padding:8px 16px;border-radius:999px;background:rgba(124,58,237,.2);border:1px solid rgba(249,115,22,.4);font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:#fcd34d}
+.challenge-controls{display:flex;flex-wrap:wrap;gap:18px;justify-content:center;align-items:center;margin-top:12px}
+.countdown--pumpkin{background:rgba(249,115,22,.12);border-color:rgba(249,115,22,.45);color:#fb923c;box-shadow:0 0 0 1px rgba(249,115,22,.25)}
+.challenge-main{display:grid;gap:28px;padding-bottom:56px}
+@media(min-width:960px){.challenge-main{grid-template-columns:minmax(0,1.05fr)minmax(0,1fr)}}
+.card--moonlight{position:relative;overflow:hidden;background:linear-gradient(160deg,rgba(30,24,68,.85),rgba(16,12,46,.92));border-color:rgba(148,119,255,.32);box-shadow:0 20px 40px rgba(15,8,40,.4)}
+.card--moonlight::after{content:"";position:absolute;inset:auto -40% -40% 40%;height:220px;background:radial-gradient(circle at 50% 50%,rgba(124,58,237,.35),rgba(15,8,40,0));pointer-events:none;opacity:.6}
+.challenge-panel{position:relative;padding-bottom:28px;box-shadow:0 24px 48px rgba(8,5,24,.55)}
+.spooky-list{margin:0;padding-left:22px;display:grid;gap:12px;color:#f3e8ff}
+.spooky-list li{line-height:1.5}
+.spooky-list strong{color:#fcd34d}
+.scenario-grid{display:grid;gap:20px;margin-top:12px}
+.scenario-placeholder{padding:28px;border:1px dashed rgba(124,58,237,.4);border-radius:16px;text-align:center;color:#cbb7ff;background:rgba(18,16,42,.65)}
+.scenario-card{position:relative;padding:22px;border-radius:18px;background:linear-gradient(160deg,rgba(24,18,58,.95),rgba(12,10,30,.96));border:1px solid rgba(148,119,255,.24);box-shadow:0 16px 36px rgba(8,5,24,.55);transition:transform .25s ease,border-color .25s ease,box-shadow .25s ease}
+.scenario-card:hover{transform:translateY(-4px);border-color:rgba(249,115,22,.45);box-shadow:0 24px 40px rgba(10,6,28,.6)}
+.scenario-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px;font-size:.85rem;text-transform:uppercase;letter-spacing:.08em;color:#cbb7ff}
+.scenario-label{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:rgba(124,58,237,.2);border:1px solid rgba(124,58,237,.35)}
+.scenario-tag{font-weight:700;color:#fcd34d}
+.scenario-meta{display:grid;gap:4px;font-size:.9rem;color:#d8ceff}
+.scenario-meta strong{color:#fef9ff}
+.scenario-preview{margin:16px 0 10px;line-height:1.5;color:#f4efff}
+.scenario-detail{margin:0 0 18px;font-size:.9rem;color:#cbb7ff}
+.scenario-choice-row{display:flex;flex-wrap:wrap;gap:12px}
+.choice-chip{position:relative;display:inline-flex}
+.choice-chip input{position:absolute;opacity:0;pointer-events:none}
+.choice-chip span{display:inline-flex;align-items:center;gap:6px;padding:10px 16px;border-radius:999px;border:1px solid rgba(148,119,255,.4);background:rgba(36,26,74,.8);font-weight:600;color:#eaddff;cursor:pointer;transition:transform .18s ease,border-color .18s ease,background .18s ease,box-shadow .18s ease}
+.choice-chip span::before{content:"";width:10px;height:10px;border-radius:50%;background:rgba(148,119,255,.55);box-shadow:0 0 12px rgba(124,58,237,.55)}
+.choice-chip input:checked + span{transform:translateY(-2px);border-color:rgba(249,115,22,.6);background:rgba(249,115,22,.18);color:#fef3c7;box-shadow:0 10px 22px rgba(249,115,22,.35)}
+.choice-chip--danger span{border-color:rgba(249,115,22,.4);background:rgba(54,22,10,.65)}
+.choice-chip--danger span::before{background:rgba(249,115,22,.7);box-shadow:0 0 12px rgba(249,115,22,.6)}
+.scenario-card--correct{border-color:rgba(52,211,153,.55);box-shadow:0 24px 44px rgba(34,197,94,.35)}
+.scenario-card--incorrect{border-color:rgba(248,113,113,.55);box-shadow:0 24px 44px rgba(248,113,113,.3)}
+.scenario-reveal{margin-top:18px;padding-top:16px;border-top:1px solid rgba(148,119,255,.28);display:grid;gap:10px}
+.reveal-result{font-weight:700;font-size:1rem}
+.reveal-result--correct{color:#34d399}
+.reveal-result--incorrect{color:#f87171}
+.reveal-insights{margin:0;padding-left:20px;color:#e9ddff;font-size:.92rem;display:grid;gap:6px}
+.reveal-action{margin:0;font-size:.9rem;color:#fcd34d}
+.challenge-actions{margin-top:24px;display:flex;flex-wrap:wrap;gap:16px;align-items:center;justify-content:space-between}
+.progress-pill{display:inline-flex;align-items:center;gap:8px;padding:8px 14px;border-radius:999px;background:rgba(148,119,255,.2);border:1px solid rgba(148,119,255,.35);font-weight:600;color:#eaddff;font-size:.85rem}
+
+.phish-treat-page .summary-banner{background:rgba(29,20,58,.85);border-color:rgba(124,58,237,.38);color:#f9fafb}


### PR DESCRIPTION
## Summary
- add a Halloween "Phish or Treat" challenge page with countdown instructions and submission flow
- implement the 3-minute phishing classification game logic, including timed auto-submission and scenario reveals
- extend shared styling with seasonal theme elements and surface the new page from the home hero actions

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3dfd3fe188333a1e614715de3b4b5